### PR TITLE
Fix device host discovery in config flow

### DIFF
--- a/custom_components/dyson_local/config_flow.py
+++ b/custom_components/dyson_local/config_flow.py
@@ -214,6 +214,7 @@ class DysonLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> Optional[str]:
         """Try connect and return config entry data."""
         device = get_device(serial, credential, device_type)
+        saved_host = host
 
         # Find device using discovery
         if not host:
@@ -250,7 +251,7 @@ class DysonLocalConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_CREDENTIAL: credential,
             CONF_DEVICE_TYPE: device_type,
             CONF_NAME: name,
-            CONF_HOST: host,
+            CONF_HOST: saved_host,
         }
 
 


### PR DESCRIPTION
I setup my device with host discovery, but at some point the IP address of the device changed and HA lost connectivity. Looking through the code, the devices support discovery in `async_setup_entry` but only if the `host` was not set during the config flow.

Turns out the discovered host is being returned from `_async_get_entry_data` and saved to the config entry data. This small PR fixes that issue and will cause the host to be auto discovered.