### PR TITLE
Add entities for DysonAirQualitySelect

### DIFF
--- a/custom_components/dyson_local/select.py
+++ b/custom_components/dyson_local/select.py
@@ -2,7 +2,13 @@
 
 from typing import Callable
 
-from libdyson import DysonPureHumidifyCool, HumidifyOscillationMode, WaterHardness
+from libdyson import (
+    DysonPureHumidifyCool,
+    DysonPureHotCoolLink,
+    DysonPureCoolLink,
+    HumidifyOscillationMode,
+    WaterHardness,
+)
 from libdyson.const import AirQualityTarget
 
 from homeassistant.components.select import SelectEntity
@@ -54,6 +60,10 @@ async def async_setup_entry(
     device = hass.data[DOMAIN][DATA_DEVICES][config_entry.entry_id]
     name = config_entry.data[CONF_NAME]
     entities = []
+    if isinstance(device, DysonPureHotCoolLink) or isinstance(
+        device, DysonPureCoolLink
+    ):
+        entities.append(DysonAirQualitySelect(device, name))
     if isinstance(device, DysonPureHumidifyCool):
         entities.extend(
             [


### PR DESCRIPTION
#69 implemented a select entity `DysonAirQualitySelect` to set the equivalent of the "personalised auto target" setting in the Dyson app, but never added the entity in `async_setup_entry`. This PR adds the entity for `DysonPureHotCoolLink` and `DysonPureCoolLink` device types. It may be applicable to additional types as well, but these are the only two types of air treatment devices that I have.