### PR TITLE
fan, vacuum: replace device_state_attributes usage.

### DIFF
--- a/custom_components/dyson_local/fan.py
+++ b/custom_components/dyson_local/fan.py
@@ -2,7 +2,7 @@
 
 import logging
 import math
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Mapping, Optional
 
 from libdyson import DysonPureCool, DysonPureCoolLink, MessageType
 import voluptuous as vol
@@ -223,8 +223,8 @@ class DysonPureCoolEntity(DysonFanEntity):
         return self._device.oscillation_angle_high
 
     @property
-    def device_state_attributes(self) -> dict:
-        """Return optional state attributes."""
+    def extra_state_attributes(self) -> Mapping[str, Any]:
+        """Return fan-specific state attributes."""
         return {
             ATTR_ANGLE_LOW: self.angle_low,
             ATTR_ANGLE_HIGH: self.angle_high,

--- a/custom_components/dyson_local/vacuum.py
+++ b/custom_components/dyson_local/vacuum.py
@@ -1,6 +1,6 @@
 """Vacuum platform for Dyson."""
 
-from typing import Callable, List
+from typing import Any, Callable, List, Mapping
 
 from libdyson import (
     Dyson360Eye,
@@ -172,7 +172,7 @@ class DysonVacuumEntity(DysonEntity, StateVacuumEntity):
         return SUPPORTED_FEATURES
 
     @property
-    def device_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> Mapping[str, Any]:
         """Expose the status to state attributes."""
         return {
             ATTR_POSITION: str(self._device.position),


### PR DESCRIPTION
The device_state_attributes property has been deprecated since 2021.4
but only just started issuing startup logs.

This addresses Issue #78.
