### PR TITLE
Do not convert the target temperature to integer

### DIFF
--- a/custom_components/dyson_local/climate.py
+++ b/custom_components/dyson_local/climate.py
@@ -125,7 +125,6 @@ class DysonClimateEntity(DysonEntity, ClimateEntity):
         if target_temp is None:
             _LOGGER.error("Missing target temperature %s", kwargs)
             return
-        target_temp = int(target_temp)
         _LOGGER.debug("Set %s temperature %s", self.name, target_temp)
         # Limit the target temperature into acceptable range.
         target_temp = min(self.max_temp, target_temp)


### PR DESCRIPTION
In places where Fahrenheit is the default temperature scale (like
US), home assistant UI shows the climate cards in Fahrenheit scale
and converts the temperature to Celcius implicitly for integrations
that use Celcius.

So the set_temperature() calls in this case will get a floating
point temperature value for celcius and converting that to an integer
before converting that to Kelvin makes setting certain temperature
values in Fahrenheit impossible because of the rounding errors.

Consider the following case:
User sets 74F -> Home assistant converts it to 23.3C -> Converting
that to integer becomes 23C which is equivalent to 73F. So setting
74F is impossible because of this rounding.

Not converting the value to integer and converting directly to a
floating point Kelvin temperature solves this issue and users would
be able to set any Fahrenheit temperatures they want. Note that the
underlying libdyson library supports setting any floating point
temperature in Kelvin and the rounding to integer was not really
necessary in the first place.