### PR TITLE
Updates to 2021.12.0 best practices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Dyson Local uses MQTT-based protocol to communicate with local Dyson devices usi
 - Dyson Pure Hot+Cool Link
 - Dyson Pure Humidity+Cool
 
-Humidifier support under HA platform `humidifier` is not supported yet.
-
 ### Dyson Cloud
 
 Dyson Cloud uses HTTP-based API to communicate with cloud service. Currently it supports getting device credentials and show all devices as discovered entities under the Integrations page. It also supports getting cleaning maps as `camera` entities for 360 Eye robot vacuum.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ My goal is to make this integration official. However, at the current stage, I d
 
 ## Installation
 
+The minimum supported Home Assistant version is 2021.12.0.
+
 You can install using HACS. Adding https://github.com/shenxn/ha-dyson as custom repository and then install Dyson Local. If you want cloud functionalities as well, add https://github.com/shenxn/ha-dyson-cloud and install Dyson Cloud.
 
 You can also install manually

--- a/custom_components/dyson_local/binary_sensor.py
+++ b/custom_components/dyson_local/binary_sensor.py
@@ -9,8 +9,9 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, ENTITY_CATEGORY_DIAGNOSTIC
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 
 from . import DysonEntity
 from .const import DATA_DEVICES, DOMAIN
@@ -42,7 +43,7 @@ async def async_setup_entry(
 class DysonVacuumBatteryChargingSensor(DysonEntity, BinarySensorEntity):
     """Dyson vacuum battery charging sensor."""
 
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def is_on(self) -> bool:
@@ -68,7 +69,7 @@ class DysonVacuumBatteryChargingSensor(DysonEntity, BinarySensorEntity):
 class Dyson360HeuristBinFullSensor(DysonEntity, BinarySensorEntity):
     """Dyson 360 Heurist bin full sensor."""
 
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def is_on(self) -> bool:
@@ -94,7 +95,7 @@ class Dyson360HeuristBinFullSensor(DysonEntity, BinarySensorEntity):
 class DysonPureHotCoolLinkTiltSensor(DysonEntity, BinarySensorEntity):
     """Dyson Pure Hot+Cool Link tilt sensor."""
 
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:angle-acute"
 
     @property

--- a/custom_components/dyson_local/select.py
+++ b/custom_components/dyson_local/select.py
@@ -3,9 +3,9 @@
 from typing import Callable
 
 from libdyson import (
-    DysonPureHumidifyCool,
-    DysonPureHotCoolLink,
     DysonPureCoolLink,
+    DysonPureHotCoolLink,
+    DysonPureHumidifyCool,
     HumidifyOscillationMode,
     WaterHardness,
 )
@@ -13,8 +13,9 @@ from libdyson.const import AirQualityTarget
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, ENTITY_CATEGORY_CONFIG
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 
 from . import DysonEntity
 from .const import DATA_DEVICES, DOMAIN
@@ -77,7 +78,7 @@ async def async_setup_entry(
 class DysonAirQualitySelect(DysonEntity, SelectEntity):
     """Air quality target for supported models."""
 
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_options = list(AIR_QUALITY_TARGET_STR_TO_ENUM.keys())
 
     @property
@@ -103,7 +104,7 @@ class DysonAirQualitySelect(DysonEntity, SelectEntity):
 class DysonOscillationModeSelect(DysonEntity, SelectEntity):
     """Oscillation mode for supported models."""
 
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:sync"
     _attr_options = list(OSCILLATION_MODE_STR_TO_ENUM.keys())
 
@@ -130,7 +131,7 @@ class DysonOscillationModeSelect(DysonEntity, SelectEntity):
 class DysonWaterHardnessSelect(DysonEntity, SelectEntity):
     """Dyson Pure Humidify+Cool Water Hardness Select."""
 
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:water-opacity"
     _attr_options = list(WATER_HARDNESS_STR_TO_ENUM.keys())
 

--- a/custom_components/dyson_local/sensor.py
+++ b/custom_components/dyson_local/sensor.py
@@ -11,24 +11,17 @@ from libdyson import (
 )
 from libdyson.const import MessageType
 
-from homeassistant.components.sensor import DEVICE_CLASS_BATTERY, SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONF_NAME,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_NITROGEN_DIOXIDE,
-    DEVICE_CLASS_PM1,
-    DEVICE_CLASS_PM10,
-    DEVICE_CLASS_PM25,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS,
-    ENTITY_CATEGORY_DIAGNOSTIC,
     PERCENTAGE,
     TEMP_CELSIUS,
     TIME_HOURS,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -123,7 +116,7 @@ class DysonBatterySensor(DysonSensor):
 
     _SENSOR_TYPE = "battery_level"
     _SENSOR_NAME = "Battery Level"
-    _attr_device_class = DEVICE_CLASS_BATTERY
+    _attr_device_class = SensorDeviceClass.BATTERY
     _attr_unit_of_measurement = PERCENTAGE
 
     @property
@@ -137,7 +130,7 @@ class DysonFilterLifeSensor(DysonSensor):
 
     _SENSOR_TYPE = "filter_life"
     _SENSOR_NAME = "Filter Life"
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:filter-outline"
     _attr_unit_of_measurement = TIME_HOURS
 
@@ -152,7 +145,7 @@ class DysonCarbonFilterLifeSensor(DysonSensor):
 
     _SENSOR_TYPE = "carbon_filter_life"
     _SENSOR_NAME = "Carbon Filter Life"
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:filter-outline"
     _attr_unit_of_measurement = PERCENTAGE
 
@@ -167,7 +160,7 @@ class DysonHEPAFilterLifeSensor(DysonSensor):
 
     _SENSOR_TYPE = "hepa_filter_life"
     _SENSOR_NAME = "HEPA Filter Life"
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:filter-outline"
     _attr_unit_of_measurement = PERCENTAGE
 
@@ -182,7 +175,7 @@ class DysonCombinedFilterLifeSensor(DysonSensor):
 
     _SENSOR_TYPE = "combined_filter_life"
     _SENSOR_NAME = "Filter Life"
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:filter-outline"
     _attr_unit_of_measurement = PERCENTAGE
 
@@ -197,7 +190,7 @@ class DysonNextDeepCleanSensor(DysonSensor):
 
     _SENSOR_TYPE = "next_deep_clean"
     _SENSOR_NAME = "Next Deep Clean"
-    _attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_icon = "mdi:filter-outline"
     _attr_unit_of_measurement = TIME_HOURS
 
@@ -212,7 +205,7 @@ class DysonHumiditySensor(DysonSensorEnvironmental):
 
     _SENSOR_TYPE = "humidity"
     _SENSOR_NAME = "Humidity"
-    _attr_device_class = DEVICE_CLASS_HUMIDITY
+    _attr_device_class = SensorDeviceClass.HUMIDITY
     _attr_unit_of_measurement = PERCENTAGE
 
     @environmental_property
@@ -226,7 +219,7 @@ class DysonTemperatureSensor(DysonSensorEnvironmental):
 
     _SENSOR_TYPE = "temperature"
     _SENSOR_NAME = "Temperature"
-    _attr_device_class = DEVICE_CLASS_TEMPERATURE
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_unit_of_measurement = TEMP_CELSIUS
 
     @environmental_property
@@ -254,7 +247,7 @@ class DysonPM25Sensor(DysonSensorEnvironmental):
 
     _SENSOR_TYPE = "pm25"
     _SENSOR_NAME = "PM 2.5"
-    _attr_device_class = DEVICE_CLASS_PM25
+    _attr_device_class = SensorDeviceClass.PM25
     _attr_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     @environmental_property
@@ -268,7 +261,7 @@ class DysonPM10Sensor(DysonSensorEnvironmental):
 
     _SENSOR_TYPE = "pm10"
     _SENSOR_NAME = "PM 10"
-    _attr_device_class = DEVICE_CLASS_PM10
+    _attr_device_class = SensorDeviceClass.PM10
     _attr_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     @environmental_property
@@ -282,7 +275,7 @@ class DysonParticulatesSensor(DysonSensorEnvironmental):
 
     _SENSOR_TYPE = "pm1"
     _SENSOR_NAME = "Particulates"
-    _attr_device_class = DEVICE_CLASS_PM1
+    _attr_device_class = SensorDeviceClass.PM1
     _attr_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     @environmental_property
@@ -296,7 +289,7 @@ class DysonVOCSensor(DysonSensorEnvironmental):
 
     _SENSOR_TYPE = "voc"
     _SENSOR_NAME = "Volatile Organic Compounds"
-    _attr_device_class = DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS
+    _attr_device_class = SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS
     _attr_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     @environmental_property
@@ -310,7 +303,7 @@ class DysonNO2Sensor(DysonSensorEnvironmental):
 
     _SENSOR_TYPE = "no2"
     _SENSOR_NAME = "Nitrogen Dioxide"
-    _attr_device_class = DEVICE_CLASS_NITROGEN_DIOXIDE
+    _attr_device_class = SensorDeviceClass.NITROGEN_DIOXIDE
     _attr_unit_of_measurement = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
 
     @environmental_property

--- a/custom_components/dyson_local/switch.py
+++ b/custom_components/dyson_local/switch.py
@@ -6,8 +6,9 @@ from libdyson import DysonPureHotCoolLink
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, ENTITY_CATEGORY_CONFIG
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 
 from . import DysonEntity
 from .const import DATA_DEVICES, DOMAIN
@@ -31,7 +32,7 @@ async def async_setup_entry(
 class DysonNightModeSwitchEntity(DysonEntity, SwitchEntity):
     """Dyson fan night mode switch."""
 
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
 
     @property
     def sub_name(self):
@@ -65,7 +66,7 @@ class DysonNightModeSwitchEntity(DysonEntity, SwitchEntity):
 class DysonContinuousMonitoringSwitchEntity(DysonEntity, SwitchEntity):
     """Dyson fan continuous monitoring."""
 
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
 
     @property
     def sub_name(self):
@@ -99,7 +100,7 @@ class DysonContinuousMonitoringSwitchEntity(DysonEntity, SwitchEntity):
 class DysonFocusModeSwitchEntity(DysonEntity, SwitchEntity):
     """Dyson Pure Hot+Cool Link focus mode switch."""
 
-    _attr_entity_category = ENTITY_CATEGORY_CONFIG
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:image-filter-center-focus"
 
     @property


### PR DESCRIPTION
- Use the newly defined (2021.12.0) enums instead of constants.
- Add a note that this now requires 2021.12.0 at minimum.
- Remove out-of-date note about humidifier.
