### PR TITLE
Fix error when disabling fan timer

### DIFF
--- a/custom_components/dyson_local/fan.py
+++ b/custom_components/dyson_local/fan.py
@@ -180,7 +180,8 @@ class DysonFanEntity(DysonEntity, FanEntity):
         """Set sleep timer."""
         if timer == 0:
             self._device.disable_sleep_timer()
-        self._device.set_sleep_timer(timer)
+        else:
+            self._device.set_sleep_timer(timer)
 
 
 class DysonPureCoolLinkEntity(DysonFanEntity):


### PR DESCRIPTION
When using the `dyson_local.set_timer` service to disable a fan's timer by providing `timer: 0`, the timer would be disabled but still produce the error from issue #26. This is because the set_sleep_timer function was still being called with a value of 0 (producing the error) after the timer was already disabled using the disable_sleep_timer function. Moving set_sleep_timer under an else fixes the issue by preventing set_sleep_timer from being called if disable_sleep_timer was called.