### PR TITLE
Add support for DysonPurifierHumidifyCoolFormaldehyde

### DIFF
--- a/custom_components/dyson_local/__init__.py
+++ b/custom_components/dyson_local/__init__.py
@@ -12,6 +12,7 @@ from libdyson import (
     DysonPureHotCool,
     DysonPureHotCoolLink,
     DysonPureHumidifyCool,
+    DysonPurifierHumidifyCoolFormaldehyde,
     MessageType,
     get_device,
 )
@@ -157,7 +158,8 @@ def _async_get_platforms(device: DysonDevice) -> List[str]:
         platforms.append("climate")
     if isinstance(device, DysonPureHotCoolLink):
         platforms.extend(["binary_sensor", "climate"])
-    if isinstance(device, DysonPureHumidifyCool):
+    if isinstance(device, DysonPureHumidifyCool) or isinstance(
+        device, DysonPurifierHumidifyCoolFormaldehyde):
         platforms.append("humidifier")
     return platforms
 

--- a/custom_components/dyson_local/manifest.json
+++ b/custom_components/dyson_local/manifest.json
@@ -6,7 +6,7 @@
     "issue_tracker": "https://github.com/shenxn/ha-dyson/issues",
     "dependencies": ["zeroconf"],
     "codeowners": ["@shenxn"],
-    "requirements": ["libdyson==0.8.9"],
-    "version": "0.16.3",
+    "requirements": ["libdyson @ git+https://github.com/shenxn/libdyson@main"],
+    "version": "0.17.0",
     "iot_class": "local_polling"
 }

--- a/custom_components/dyson_local/manifest.json
+++ b/custom_components/dyson_local/manifest.json
@@ -6,7 +6,7 @@
     "issue_tracker": "https://github.com/shenxn/ha-dyson/issues",
     "dependencies": ["zeroconf"],
     "codeowners": ["@shenxn"],
-    "requirements": ["libdyson @ git+https://github.com/shenxn/libdyson@main"],
+    "requirements": ["libdyson@git+https://github.com/shenxn/libdyson@main"],
     "version": "0.17.0",
     "iot_class": "local_polling"
 }

--- a/custom_components/dyson_local/select.py
+++ b/custom_components/dyson_local/select.py
@@ -6,6 +6,7 @@ from libdyson import (
     DysonPureCoolLink,
     DysonPureHotCoolLink,
     DysonPureHumidifyCool,
+    DysonPurifierHumidifyCoolFormaldehyde,
     HumidifyOscillationMode,
     WaterHardness,
 )
@@ -65,7 +66,8 @@ async def async_setup_entry(
         device, DysonPureCoolLink
     ):
         entities.append(DysonAirQualitySelect(device, name))
-    if isinstance(device, DysonPureHumidifyCool):
+    if isinstance(device, DysonPureHumidifyCool) or isinstance(
+        device, DysonPurifierHumidifyCoolFormaldehyde):
         entities.extend(
             [
                 DysonOscillationModeSelect(device, name),

--- a/custom_components/dyson_local/sensor.py
+++ b/custom_components/dyson_local/sensor.py
@@ -8,6 +8,7 @@ from libdyson import (
     DysonDevice,
     DysonPureCoolLink,
     DysonPureHumidifyCool,
+    DysonPurifierHumidifyCoolFormaldehyde,
 )
 from libdyson.const import MessageType
 
@@ -71,7 +72,8 @@ async def async_setup_entry(
                         DysonHEPAFilterLifeSensor(device, name),
                     ]
                 )
-        if isinstance(device, DysonPureHumidifyCool):
+        if isinstance(device, DysonPureHumidifyCool) or isinstance(
+            device, DysonPurifierHumidifyCoolFormaldehyde):
             entities.append(DysonNextDeepCleanSensor(device, name))
     async_add_entities(entities)
 


### PR DESCRIPTION
I received a PH03 as a replacement for my PH01 that malfunctioned. This PH03 device reports back device type 358E, which is the same as the PH04 Formaldehyde unit. In order to get this working in HA, I had to create my own fork that grabbed the latest version of libdyson and then modify the code slightly to include the DysonPurifierHumidifyCoolFormaldehyde class. Once I did this, I was able to add the device locally without any issues (still had to get the credential manually using the main branch of libdyson).

I iterated to v0.17.0 as well in my fork, so carried that across as well in the PR.