### PR TITLE
Use native unit of measurement for Dyson temp sensor

### DIFF
--- a/custom_components/dyson_local/sensor.py
+++ b/custom_components/dyson_local/sensor.py
@@ -222,7 +222,7 @@ class DysonTemperatureSensor(DysonSensorEnvironmental):
     _SENSOR_TYPE = "temperature"
     _SENSOR_NAME = "Temperature"
     _attr_device_class = SensorDeviceClass.TEMPERATURE
-    _attr_unit_of_measurement = TEMP_CELSIUS
+    native_unit_of_measurement = TEMP_CELSIUS
 
     @environmental_property
     def temperature_kelvin(self) -> int:


### PR DESCRIPTION
This fixes #112 by switching from removed _attr_unit_of_measurement to native_unit_of_measurement for the temperature sensor. 