### PR TITLE
Fix automatic switching to heat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HomeAssistant Custom Integration for Dyson
+# Home Assistant custom integration for dyson
 
 This custom integration is still under development.
 
@@ -62,7 +62,7 @@ If you want to manually set up Dyson Local, you need to get credentials first. C
 
 ## Debug Log
 
-To enable debug log, add the following lines to your `configuration.yaml` and restart your HomeAssistant.
+To enable debug log, add the following lines to your `configuration.yaml` and restart your Home Assistant.
 
 ```yaml
 logger:

--- a/custom_components/dyson_local/climate.py
+++ b/custom_components/dyson_local/climate.py
@@ -89,7 +89,10 @@ class DysonClimateEntity(DysonEntity, ClimateEntity):
     @property
     def target_temperature(self) -> int:
         """Return the target temperature."""
-        return self._device.heat_target - 273
+        if not self._device.heat_mode_is_on:
+            return self._device.speed
+        else:
+            return self._device.heat_target - 273
 
     @environmental_property
     def _current_temperature_kelvin(self) -> int:
@@ -122,6 +125,11 @@ class DysonClimateEntity(DysonEntity, ClimateEntity):
         if not self._device.heat_mode_is_on:
             return 10
         return 37
+
+    @property
+    def target_temperature_step(self):
+        """Return the maximum temperature."""
+        return 1
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""

--- a/custom_components/dyson_local/climate.py
+++ b/custom_components/dyson_local/climate.py
@@ -20,6 +20,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_FAN_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, CONF_NAME, TEMP_CELSIUS
 from homeassistant.core import Callable, HomeAssistant
@@ -33,7 +34,6 @@ HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_COOL, HVAC_MODE_HEAT]
 FAN_MODES = [FAN_FOCUS, FAN_DIFFUSE]
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 SUPPORT_FLAGS_LINK = SUPPORT_FLAGS | SUPPORT_FAN_MODE
-
 
 async def async_setup_entry(
     hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable
@@ -112,11 +112,15 @@ class DysonClimateEntity(DysonEntity, ClimateEntity):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
+        if not self._device.heat_mode_is_on:
+            return 1
         return 1
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
+        if not self._device.heat_mode_is_on:
+            return 10
         return 37
 
     def set_temperature(self, **kwargs):
@@ -129,7 +133,10 @@ class DysonClimateEntity(DysonEntity, ClimateEntity):
         # Limit the target temperature into acceptable range.
         target_temp = min(self.max_temp, target_temp)
         target_temp = max(self.min_temp, target_temp)
-        self._device.set_heat_target(target_temp + 273)
+        if self._device.heat_mode_is_on:
+            self._device.set_heat_target(target_temp + 273)
+        else:
+            self._device.set_speed(int(target_temp))
 
     def set_hvac_mode(self, hvac_mode: str):
         """Set new hvac mode."""

--- a/custom_components/dyson_local/switch.py
+++ b/custom_components/dyson_local/switch.py
@@ -23,6 +23,8 @@ async def async_setup_entry(
     entities = [
         DysonNightModeSwitchEntity(device, name),
         DysonContinuousMonitoringSwitchEntity(device, name),
+        DysonOscillationSwitchEntity(device, name),
+        DysonAutoModeSwitchEntity(device, name),
     ]
     if isinstance(device, DysonPureHotCoolLink):
         entities.append(DysonFocusModeSwitchEntity(device, name))
@@ -125,3 +127,63 @@ class DysonFocusModeSwitchEntity(DysonEntity, SwitchEntity):
     def turn_off(self):
         """Turn off switch."""
         return self._device.disable_focus_mode()
+    
+    
+class DysonOscillationSwitchEntity(DysonEntity, SwitchEntity):
+    """Dyson Pure Hot+Cool Link oscillation switch."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:rotate-3d-variant"
+
+    @property
+    def sub_name(self):
+        """Return the name of the entity."""
+        return "Oscillation"
+
+    @property
+    def sub_unique_id(self):
+        """Return the unique id of the entity."""
+        return "oscillation"
+
+    @property
+    def is_on(self):
+        """Return if switch is on."""
+        return self._device.oscillation
+
+    def turn_on(self):
+        """Turn on switch."""
+        return self._device.enable_oscillation()
+
+    def turn_off(self):
+        """Turn off switch."""
+        return self._device.disable_oscillation()
+    
+    
+class DysonAutoModeSwitchEntity(DysonEntity, SwitchEntity):
+    """Dyson Pure Hot+Cool Link auto mode switch."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:fan-auto"
+
+    @property
+    def sub_name(self):
+        """Return the name of the entity."""
+        return "Auto Mode"
+
+    @property
+    def sub_unique_id(self):
+        """Return the unique id of the entity."""
+        return "auto_mode"
+
+    @property
+    def is_on(self):
+        """Return if switch is on."""
+        return self._device.auto_mode
+
+    def turn_on(self):
+        """Turn on switch."""
+        return self._device.enable_auto_mode()
+
+    def turn_off(self):
+        """Turn off switch."""
+        return self._device.disable_auto_mode()

--- a/custom_components/dyson_local/translations/de.json
+++ b/custom_components/dyson_local/translations/de.json
@@ -1,0 +1,42 @@
+{
+    "config":{
+       "flow_title":"Dyson - {name} ({serial})",
+       "step":{
+          "user":{
+             "data":{
+                "method":"Einrichtungsmethode"
+             }
+          },
+          "wifi":{
+             "description":"Gebe die WiFi-Informationen von dem Aufkleber auf dem Gerät und aus dem Benutzerhandbuch ein. (Nicht die WiFi-Informationen für Ihr Zuhause)",
+             "data":{
+                "ssid":"SSID Name (Product SSID)",
+                "password":"SSID Passwort (Product Wi-Fi Password)",
+                "host":"Host (Optional)"
+             }
+          },
+          "manual":{
+             "data":{
+                "serial":"Seriennummer",
+                "credential":"Berechtigungsnachweis (Credential)",
+                "host":"Host (Optional)",
+                "device_type":"Gerätetyp"
+             }
+          },
+          "host":{
+             "data":{
+                "host":"Host (Optional)"
+             }
+          }
+       },
+       "error":{
+          "cannot_connect":"Verbindung fehlgeschlagen",
+          "cannot_find":"Das Gerät konnte mit der Erkennung nicht gefunden werden",
+          "invalid_auth":"Ungültige Authentifizierung",
+          "cannot_parse_wifi_info":"Fehler beim Einfügen der WiFi-Informationen des Geräts"
+       },
+       "abort":{
+          "already_configured":"Gerät bereits konfiguriert"
+       }
+    }
+ }

--- a/custom_components/dyson_local/translations/en.json
+++ b/custom_components/dyson_local/translations/en.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Dyson: {name} ({serial})",
+    "flow_title": "Dyson - {name} ({serial})",
     "step": {
       "user": {
         "data": {
@@ -10,8 +10,8 @@
       "wifi": {
         "description": "Find your device WiFi information from the sticker on your device body or user's manual. Don't fill in your home WiFi info.",
         "data": {
-          "ssid": "Device WiFi SSID",
-          "password": "Device WiFi Password",
+          "ssid": "Product SSID",
+          "password": "Product Wi-Fi Password",
           "host": "Host (Optional)"
         }
       },


### PR DESCRIPTION
Hello this small patch adds the two switches "Auto Mode" and "Oscillation" to the integration. It also fixes the bug that when the slider is moved in the thermostat, it automatically switches to heat mode.

With normal thermostats this makes sense, here with the example "Dyson Pure Hot+Cool" it is only a hindrance and uncomfortable. 

Thank you for all your work and for making the integration possible.

Changelog:
Fixing the error when adjusting the temperature in the thermostat (Automatic switching to heat mode)
Adding switch "Auto Mode" and "Oscillation"